### PR TITLE
Links to prebuilt binaries for cf cli

### DIFF
--- a/first-push/student-template.md
+++ b/first-push/student-template.md
@@ -36,7 +36,7 @@ If you installed the CLI successfully, you should be able to open a terminal win
 
 ```
 $ cf version
-6.33.0+a345ea34d.2017-11-20
+cf version 6.34.1+bbdf81482.2018-01-17
 ```
 
 ### Using the CLI


### PR DESCRIPTION
@spgreenberg 

The stock installation instructions kinda suck.  I'm thinking it's better for our target audience if we just link to the prebuilt binaries.

I'd _love_ to just vendor the bins in this repo, but I'm not clear on whether the audience will be expected to have this repo locally cloned, and the bins are large enough that they'd have to install [git lfs](https://git-lfs.github.com/).